### PR TITLE
feat: removing remote player when closing app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@ import {
 } from '@expo-google-fonts/roboto';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ScrollView, StatusBar, StyleSheet, View } from 'react-native';
 import TrackPlayer from 'react-native-track-player';
 import VideoSelector from './src/components/VideoSelector';
@@ -24,6 +24,14 @@ const App = () => {
     Roboto_900Black,
   });
 
+  useEffect(() => {
+    return () => {
+      try {
+        TrackPlayer.reset();
+      } catch (e) {}
+    };
+  }, []);
+
   const onLayoutRootView = useCallback(async () => {
     if (fontsLoaded || fontError) {
       await SplashScreen.hideAsync().then(async () => {
@@ -33,7 +41,7 @@ const App = () => {
         }
       });
     }
-  }, [fontsLoaded, fontError]);
+  }, [fontsLoaded, fontError, isSetUp]);
 
   if (!fontsLoaded && !fontError) {
     return null;

--- a/src/services/track-player.ts
+++ b/src/services/track-player.ts
@@ -1,10 +1,12 @@
-import TrackPlayer from 'react-native-track-player';
+import TrackPlayer, { Event } from 'react-native-track-player';
 
 module.exports = async function () {
-  TrackPlayer.addEventListener('remote-play', () => TrackPlayer.play());
-  TrackPlayer.addEventListener('remote-pause', () => TrackPlayer.pause());
-  TrackPlayer.addEventListener('remote-next', () => TrackPlayer.skipToNext());
-  TrackPlayer.addEventListener('remote-previous', () =>
-    TrackPlayer.skipToPrevious(),
-  );
+  TrackPlayer.addEventListener(Event.RemotePlay, () => TrackPlayer.play());
+  TrackPlayer.addEventListener(Event.RemotePause, () => TrackPlayer.pause());
+  // TrackPlayer.addEventListener(Event.RemoteNext, () =>
+  //   TrackPlayer.skipToNext(),
+  // );
+  // TrackPlayer.addEventListener(Event.RemotePrevious, () =>
+  //   TrackPlayer.skipToPrevious(),
+  // );
 };


### PR DESCRIPTION
### What

When closing the app, the remote player was opened until the app was removed/killed from the list of apps. Now, when the app is closed, the player is also closed.